### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 I wrote this small library because I needed to [somewhat] automate integration testing with BLE devices which is not possible to do using unit tests. This test suite is based on (but does not inherit from) the XCTestCase class. It has the same 'kind' of functionality, including `setUp` and `tearDown` functions. It also scans your implementation file for any methods prefixed with "test" (i.e. `testSomething`, `testSomethingElse`).
 
-## Installation using Cocoapods
+## Installation using CocoaPods
 
 ```ruby
 pod 'BZKIntegrationTestSuite'


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
